### PR TITLE
Remove port usage in evt file.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         version:
           - zeek:6.0
+          - zeek:7.0
           - zeek-dev:latest
 
       fail-fast: false

--- a/analyzer/tftp.evt
+++ b/analyzer/tftp.evt
@@ -3,8 +3,7 @@
 # Note: When line numbers change in this file, update the documentation that pulls it in.
 
 protocol analyzer spicy::TFTP over UDP:
-    parse with TFTP::Packet,
-    port 69/udp;
+    parse with TFTP::Packet;
 
 import TFTP;
 

--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -40,6 +40,9 @@ export {
 
 	## Event that can be handled to access the TFTP logging record.
 	global log_tftp: event(rec: Info);
+
+	## The well-known TFT ports to register the analyzer for.
+	global ports: set[port] = { 69/udp, } &redef;
 }
 
 # Maps a partial data connection ID to the request's Info record.
@@ -51,6 +54,8 @@ redef record connection += {
 
 event zeek_init() &priority=5
 	{
+	Analyzer::register_for_ports(Analyzer::ANALYZER_SPICY_TFTP, ports);
+
 	Log::create_stream(TFTP::LOG, [$columns = Info, $ev = log_tftp, $path="tftp"]);
 	}
 


### PR DESCRIPTION
This has been removed in Zeek 7.1. Zeek's base scripts will register the replaced analyzer.